### PR TITLE
AP-1694 Fix calculation of payment request hash

### DIFF
--- a/src/main/java/com/apruve/LineItem.java
+++ b/src/main/java/com/apruve/LineItem.java
@@ -2,6 +2,8 @@ package com.apruve;
 
 import java.io.Serializable;
 
+import net.sf.json.processors.PropertyNameProcessor;
+
 /**
  * Represents a line item on a PaymentRequest.
  * 
@@ -10,18 +12,48 @@ import java.io.Serializable;
  */
 public class LineItem implements Serializable {
 	private static final long serialVersionUID = 8079294991285612248L;
+	public static final PropertyNameProcessor JSON_PROP_NAME_PROCESSOR;
+	static {
+		JSON_PROP_NAME_PROCESSOR = new PropertyNameProcessor() {
+			@SuppressWarnings("rawtypes")
+			@Override
+			public String processPropertyName(Class parentClass,
+					String propertyName) {
+				String jsonName = propertyName;
+				switch (propertyName) {
+				case "amountCents":
+					jsonName = "amount_cents";
+					break;
+				case "priceEachCents":
+					jsonName = "price_ea_cents";
+					break;
+				case "variantInfo":
+					jsonName = "variant_info";
+					break;
+				case "viewProductUrl":
+					jsonName = "view_product_url";
+				}
+				return jsonName;
+			}
+		};
+	}
+
 	private Integer amountCents = null;
+	private Integer priceEachCents = null;
 	private String currency = null;
 	private Integer quantity = null;
 	private String title = null;
 	private String description = null;
 	private String sku = null;
+	private String variantInfo = null;
+	private String vendor = null;
+	private String viewProductUrl = null;
 
-	public Integer getAmount_cents() {
+	public Integer getAmountCents() {
 		return amountCents;
 	}
 
-	public void setAmount_cents(Integer amountCents) {
+	public void setAmountCents(Integer amountCents) {
 		this.amountCents = amountCents;
 	}
 
@@ -63,6 +95,38 @@ public class LineItem implements Serializable {
 
 	public void setSku(String sku) {
 		this.sku = sku;
+	}
+
+	public Integer getPriceEachCents() {
+		return priceEachCents;
+	}
+
+	public void setPriceEachCents(Integer priceEachCents) {
+		this.priceEachCents = priceEachCents;
+	}
+
+	public String getVariantInfo() {
+		return variantInfo;
+	}
+
+	public void setVariantInfo(String variantInfo) {
+		this.variantInfo = variantInfo;
+	}
+
+	public String getVendor() {
+		return vendor;
+	}
+
+	public void setVendor(String vendor) {
+		this.vendor = vendor;
+	}
+
+	public String getViewProductUrl() {
+		return viewProductUrl;
+	}
+
+	public void setViewProductUrl(String viewProductUrl) {
+		this.viewProductUrl = viewProductUrl;
 	}
 
 }

--- a/src/test/java/com/apruve/PaymentRequestTest.java
+++ b/src/test/java/com/apruve/PaymentRequestTest.java
@@ -12,6 +12,9 @@ public class PaymentRequestTest {
 	private static final String JSON_SIMPLE = "{\"amount_cents\":100,\"line_items\":[{\"amount_cents\":100,\"title\":\"A Line Item\"}],\"merchant_id\":\"AMerchantId\"}";
 	private static final String JSON_COMPLEX = "{\"amount_cents\":100,\"line_items\":[{\"amount_cents\":100,\"title\":\"A Line Item\"},{\"amount_cents\":100,\"description\":\"A discription for this line\",\"sku\":\"A_SKU_NUMBER\",\"title\":\"Another Line Item\"}],\"merchant_id\":\"AMerchantId\"}";
 	private static final String JSON_RECURRING = "{\"amount_cents\":100,\"line_items\":[{\"amount_cents\":100,\"title\":\"A Line Item\"}],\"merchant_id\":\"AMerchantId\",\"recurring\":true}";
+	private static final String VALUES_SIMPLE = "AMerchantId100A Line Item100";
+	private static final String VALUES_COMPLEX = "AMerchantId100A Line Item100Another Line Item100A discription for this lineA_SKU_NUMBER";
+	private static final String VALUES_RECURRING = "AMerchantId100trueA Line Item100";
 
 	@After
 	public void teardown() {
@@ -33,49 +36,52 @@ public class PaymentRequestTest {
 
 	@Test
 	public void testToJsonSimple() {
-		String hash = "a082bc92a6f318bd0316aa9fa4476b7b03416f7292aab6f15d3823065d6b9545";
+		String hash = "b0824ba617aa53e52828de5e2a3bbbda279def354cf536f38f728a309fad208a";
 		ApruveMerchant.init(A_MERCHANT_ID, AN_API_KEY, ApruveEnvironment.TEST);
 		PaymentRequest pr = new PaymentRequest();
 		pr.setAmountCents(new Integer(100));
 		pr.getLineItems().add(createLine1());
+		assertEquals(VALUES_SIMPLE, pr.toValueString());
 		assertEquals(JSON_SIMPLE, pr.toJson());
 		assertEquals(hash, pr.toSecureHash());
 	}
 
 	@Test
 	public void testToJsonComplex() {
-		String hash = "95521aaff07dbdf44b37039ab6c6ed337c05900c5ec6b2a7c1415e08bfdb9b63";
+		String hash = "8e7e6508359eabe96201e89c452041fbc9687e4ecf91184418001be5dce96b26";
 		ApruveMerchant.init(A_MERCHANT_ID, AN_API_KEY, ApruveEnvironment.TEST);
 		PaymentRequest pr = new PaymentRequest();
 		pr.setAmountCents(new Integer(100));
 		pr.getLineItems().add(createLine1());
 		pr.getLineItems().add(createLine2());
+		assertEquals(VALUES_COMPLEX, pr.toValueString());
 		assertEquals(JSON_COMPLEX, pr.toJson());
 		assertEquals(hash, pr.toSecureHash());
 	}
 
 	@Test
 	public void testToJsonRecurring() {
-		String hash = "bc910beef1ac61f93e2f93c05842a242fab3a414c966492c908eb1efb32f6fe6";
+		String hash = "f3b49ae3ace5ebacda919d4ac80e1be03dea70e40ffa842116c56354773422e2";
 		ApruveMerchant.init(A_MERCHANT_ID, AN_API_KEY, ApruveEnvironment.TEST);
 		PaymentRequest pr = new PaymentRequest();
 		pr.setAmountCents(new Integer(100));
 		pr.setRecurring(new Boolean(true));
 		pr.getLineItems().add(createLine1());
+		assertEquals(VALUES_RECURRING, pr.toValueString());
 		assertEquals(JSON_RECURRING, pr.toJson());
 		assertEquals(hash, pr.toSecureHash());
 	}
 	
 	public LineItem createLine1() {
 		LineItem line = new LineItem();
-		line.setAmount_cents(new Integer(100));
+		line.setAmountCents(100);
 		line.setTitle("A Line Item");
 		return line;
 	}
 
 	public LineItem createLine2() {
 		LineItem line = new LineItem();
-		line.setAmount_cents(new Integer(100));
+		line.setAmountCents(100);
 		line.setTitle("Another Line Item");
 		line.setDescription("A discription for this line");
 		line.setSku("A_SKU_NUMBER");


### PR DESCRIPTION
The hash calculation wasn't ordering the values correctly.  Also added in a few missing line item fields and added a JSON property name mapping for line items so that methods didn't have to use snake case.
